### PR TITLE
[FEATURE] #38 - Service Area Cards

### DIFF
--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -119,7 +119,7 @@
 			</article>
 
 		</div>
-		<p>Niet zeker of we in jouw buurt rijden? Neem contact met ons op voor meer informatie!</p>
+		<p class="sub-text">Niet zeker of we in jouw buurt rijden? Neem contact met ons op voor meer informatie!</p>
 	</div>
 </section>
 
@@ -131,7 +131,14 @@
         h2 {
             font-size: var(--fs-hl-lg);
         }
+		p {
+			font-size: var(--fs-hl-md-mobile);
+		}
     }
+
+	.sub-text {
+		font-size: var(--fs-label-sm-mobile) !important;
+	}
 
 	.contact-section {
 		.section-inner {
@@ -210,6 +217,13 @@
 			flex-direction: column;
 			gap: var(--space-8);
 			margin: var(--space-8) 0 var(--space-8) 0;
+			@media ( min-width: 1024px ) {
+				flex-direction: row;
+				gap: var(--space-6);
+				.area-card {
+					flex: 1;
+				}
+			}
 			.area-card {
 				background-color: var(--c-white);
 				padding: var(--space-6);


### PR DESCRIPTION
## What does this change?

This PR adds the **Service Area Cards** section to clearly show where Rijschool All Drive provides driving lessons (Amsterdam + surrounding areas).  
It improves clarity for visitors, supports local SEO, and keeps the layout consistent across breakpoints.

Resolves issue #38 

---

## How Has This Been Tested?

* [ ] User test
* [ ] Accessibility test
* [ ] Performance test
* [x] Responsive Design test
* [x] Device test
* [x] Browser test

---

## Images

Desktop  
<img width="1377" height="608" alt="afbeelding" src="https://github.com/user-attachments/assets/bda9109a-3714-4fee-90b4-342e661c5484" />

Mobile  
<img width="457" height="873" alt="afbeelding" src="https://github.com/user-attachments/assets/2b80af85-33ad-4138-b70a-a36e97fd6bcd" />

---

## Testing To-Do

- [x] Check contrast for text/icons on the card background
- [x] Confirm cards are equal width on desktop (flex/grid behavior)
- [x] Test responsive behavior at common breakpoints (mobile / tablet / desktop)
- [x] Test on at least 1 real mobile device + 2 browsers (Chrome + Safari)