### PR TITLE
Feature/#46 price page

### DIFF
--- a/src/lib/components/sections/CtaSection.svelte
+++ b/src/lib/components/sections/CtaSection.svelte
@@ -1,7 +1,16 @@
+<script>
+    export let isPricePage = false;
+</script>
+
 <section class="cta-section gradient section">
     <div class="section-inner">
-        <h2>Klaar om te beginnen?</h2>
-        <p>Start vandaag nog met je eerste gratis proefles en ervaar zelf waarom zo veel leerlingen voor ons kiezen.</p>
+        {#if isPricePage}
+            <h2>Nog vragen over onze prijzen?</h2>
+            <p>Neem contact met ons op voor persoonlijk advies over welk pakket het beste bij jou past!</p>
+        {:else}
+            <h2>Klaar om te beginnen?</h2>
+            <p>Start vandaag nog met je eerste gratis proefles en ervaar zelf waarom zo veel leerlingen voor ons kiezen.</p>
+        {/if}
         <div class="cta-buttons">
             <a class="btn-white" href="https://wa.me/31627824428">Boek je proefles <span class="arrow">→</span></a>
             <a class="btn-outline" href="tel:+31627824428">Bel direct!</a>

--- a/src/routes/prijzen/+page.svelte
+++ b/src/routes/prijzen/+page.svelte
@@ -2,7 +2,8 @@
 	import 
 	{ 
 		PricingCards,
-		CtaSection 
+		CtaSection,
+		FaqSection
 	} 
 	from '$lib';
 </script>
@@ -23,5 +24,7 @@
 <section class="pricing">
 	<PricingCards />
 </section>
+
+<FaqSection />
 
 <CtaSection isPricePage={true} />

--- a/src/routes/prijzen/+page.svelte
+++ b/src/routes/prijzen/+page.svelte
@@ -97,5 +97,12 @@
 				}
 			}
 		}
+		@media (min-width: 1024px) {
+			.package-list {
+				display: grid;
+				grid-template-columns: repeat(2, 1fr);
+				gap: var(--space-6);
+			}
+		}
 	}
 </style>

--- a/src/routes/prijzen/+page.svelte
+++ b/src/routes/prijzen/+page.svelte
@@ -25,6 +25,56 @@
 	<PricingCards />
 </section>
 
+<section class="section package-info">
+	<div class="section-inner">
+		<h2>Wat je krijgt bij alle pakketten</h2>
+		<div class="package-list">
+			<article>
+				<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M 12 2 C 6.486 2 2 6.486 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 10.874 21.803984 9.7942031 21.458984 8.7832031 L 19.839844 10.402344 C 19.944844 10.918344 20 11.453 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 7.589 7.589 4 12 4 C 13.633 4 15.151922 4.4938906 16.419922 5.3378906 L 17.851562 3.90625 C 16.203562 2.71225 14.185 2 12 2 z M 21.292969 3.2929688 L 11 13.585938 L 7.7070312 10.292969 L 6.2929688 11.707031 L 11 16.414062 L 22.707031 4.7070312 L 21.292969 3.2929688 z"></path>
+                </svg>
+				<h3>Moderne lesauto's</h3>
+				<p>Al onze lesauto's zijn modern, goed onderhouden en voorzien van dubbele pedalen.</p>
+			</article>
+			<article>
+				<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M 12 2 C 6.486 2 2 6.486 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 10.874 21.803984 9.7942031 21.458984 8.7832031 L 19.839844 10.402344 C 19.944844 10.918344 20 11.453 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 7.589 7.589 4 12 4 C 13.633 4 15.151922 4.4938906 16.419922 5.3378906 L 17.851562 3.90625 C 16.203562 2.71225 14.185 2 12 2 z M 21.292969 3.2929688 L 11 13.585938 L 7.7070312 10.292969 L 6.2929688 11.707031 L 11 16.414062 L 22.707031 4.7070312 L 21.292969 3.2929688 z"></path>
+                </svg>
+				<h3>Gecertificeerde instructeurs</h3>
+				<p>Alle instructeurs zijn volledig gecertificeerd en hebben jarenlange ervaring.</p>
+			</article>
+			<article>
+				<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M 12 2 C 6.486 2 2 6.486 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 10.874 21.803984 9.7942031 21.458984 8.7832031 L 19.839844 10.402344 C 19.944844 10.918344 20 11.453 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 7.589 7.589 4 12 4 C 13.633 4 15.151922 4.4938906 16.419922 5.3378906 L 17.851562 3.90625 C 16.203562 2.71225 14.185 2 12 2 z M 21.292969 3.2929688 L 11 13.585938 L 7.7070312 10.292969 L 6.2929688 11.707031 L 11 16.414062 L 22.707031 4.7070312 L 21.292969 3.2929688 z"></path>
+                </svg>
+				<h3>Flexibele planning</h3>
+				<p>Plan je lessen wanneer het jou uitkomt, ook 's avonds en in het weekend.</p>
+			</article>
+			<article>
+				<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M 12 2 C 6.486 2 2 6.486 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 10.874 21.803984 9.7942031 21.458984 8.7832031 L 19.839844 10.402344 C 19.944844 10.918344 20 11.453 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 7.589 7.589 4 12 4 C 13.633 4 15.151922 4.4938906 16.419922 5.3378906 L 17.851562 3.90625 C 16.203562 2.71225 14.185 2 12 2 z M 21.292969 3.2929688 L 11 13.585938 L 7.7070312 10.292969 L 6.2929688 11.707031 L 11 16.414062 L 22.707031 4.7070312 L 21.292969 3.2929688 z"></path>
+                </svg>
+				<h3>Geen verborgen kosten</h3>
+				<p>Wat je ziet is wat je betaalt. Geen verrassingen achteraf.</p>
+			</article>
+			<article>
+				<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M 12 2 C 6.486 2 2 6.486 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 10.874 21.803984 9.7942031 21.458984 8.7832031 L 19.839844 10.402344 C 19.944844 10.918344 20 11.453 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 7.589 7.589 4 12 4 C 13.633 4 15.151922 4.4938906 16.419922 5.3378906 L 17.851562 3.90625 C 16.203562 2.71225 14.185 2 12 2 z M 21.292969 3.2929688 L 11 13.585938 L 7.7070312 10.292969 L 6.2929688 11.707031 L 11 16.414062 L 22.707031 4.7070312 L 21.292969 3.2929688 z"></path>
+                </svg>
+				<h3>Ophaal- en brengservice</h3>
+				<p>We halen je op en brengen je terug na elke les binnen het verzorgingsgebied.</p>
+			</article>
+			<article>
+				<svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M 12 2 C 6.486 2 2 6.486 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 10.874 21.803984 9.7942031 21.458984 8.7832031 L 19.839844 10.402344 C 19.944844 10.918344 20 11.453 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 7.589 7.589 4 12 4 C 13.633 4 15.151922 4.4938906 16.419922 5.3378906 L 17.851562 3.90625 C 16.203562 2.71225 14.185 2 12 2 z M 21.292969 3.2929688 L 11 13.585938 L 7.7070312 10.292969 L 6.2929688 11.707031 L 11 16.414062 L 22.707031 4.7070312 L 21.292969 3.2929688 z"></path>
+                </svg>
+				<h3>Persoonlijke aanpak</h3>
+				<p>Wij geloven in een persoonlijke aanpak. Iedere leerling is uniek en krijgt de aandacht die hij of zij verdient.</p>
+			</article>
+		</div>
+	</div>
+</section>
+
 <FaqSection />
 
 <CtaSection isPricePage={true} />

--- a/src/routes/prijzen/+page.svelte
+++ b/src/routes/prijzen/+page.svelte
@@ -78,3 +78,24 @@
 <FaqSection />
 
 <CtaSection isPricePage={true} />
+
+<style>
+	.package-info {
+		background-color: var(--c-section);
+		h2 {
+			text-align: center;
+			margin-bottom: var(--space-12);
+		}
+		.package-list {
+			article {
+				background-color: var(--c-white);
+				padding: var(--space-4);
+				border-radius: var(--radius-m);
+				svg { 
+					fill: var(--c-green);
+					width: 40px;
+				}
+			}
+		}
+	}
+</style>

--- a/src/routes/prijzen/+page.svelte
+++ b/src/routes/prijzen/+page.svelte
@@ -75,6 +75,15 @@
 	</div>
 </section>
 
+<!-- <section class="section charging-container">
+	<div class="section-inner">
+		<h2>Aanvullende informatie</h2>
+		<div class="additional-info">
+		<p>Wij geloven in in transparantie. Naast de lespakketten zijn er geen verborgen kosten.</p>
+
+	</div>
+</section> -->
+
 <FaqSection />
 
 <CtaSection isPricePage={true} />

--- a/src/routes/prijzen/+page.svelte
+++ b/src/routes/prijzen/+page.svelte
@@ -1,5 +1,10 @@
 <script>
-	import { PricingCards } from '$lib';
+	import 
+	{ 
+		PricingCards,
+		CtaSection 
+	} 
+	from '$lib';
 </script>
 
 <svelte:head>
@@ -18,3 +23,5 @@
 <section class="pricing">
 	<PricingCards />
 </section>
+
+<CtaSection isPricePage={true} />

--- a/src/routes/prijzen/+page.svelte
+++ b/src/routes/prijzen/+page.svelte
@@ -85,6 +85,7 @@
 		h2 {
 			text-align: center;
 			margin-bottom: var(--space-12);
+			font-size: var(--fs-hl-lg);
 		}
 		.package-list {
 			article {


### PR DESCRIPTION
This pull request adds substantial enhancements to the pricing page, focusing on improving user clarity and engagement. The main changes include introducing a detailed section outlining what is included in all packages, updating the call-to-action to be specific for the pricing page, and integrating the FAQ and CTA components for a more informative and interactive experience.

**Pricing page content improvements:**

* Added a new `package-info` section to the pricing page, listing key features included in all packages (e.g., modern cars, certified instructors, flexible planning, no hidden costs, pickup/drop-off service, personal approach), each with descriptive text and icons.
* Integrated the `FaqSection` component to provide answers to common questions directly on the pricing page.

**Component enhancements and integration:**

* Updated the `CtaSection` component to accept an `isPricePage` prop, allowing for a tailored call-to-action message specific to the pricing page context.
* Used the `CtaSection` component with `isPricePage={true}` on the pricing page to display a relevant CTA for users interested in pricing.
* Modified imports in `src/routes/prijzen/+page.svelte` to include the new and updated components (`PricingCards`, `CtaSection`, `FaqSection`).